### PR TITLE
Hostname aangepast naar domein van de viewer en admin.

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
   "public": {
 	  "domainSuffix": "",
-	  "hostname": "http://148.251.183.26",
+	  "hostname": "http://www.handvatnationaallandschap.nl",
 	  
 	  "popupHandleiding": "popup-handleiding",
 	  "popupHelp": "popup-help",


### PR DESCRIPTION
Hierdoor leveren de calls naar de admin-api geen "mixed content" warning meer op.